### PR TITLE
Fix generic issues 

### DIFF
--- a/examples/simpleServer/data/index.htm
+++ b/examples/simpleServer/data/index.htm
@@ -31,7 +31,7 @@
       <article class="grid">
         <div>
           <hgroup>
-            <h1>ESP FS WebServer - LED Switcher</h1>
+            <h1>ESP Async FS WebServer - LED Switcher - simpleServer.ino</h1>
           </hgroup>
           <label for="remember">
             <input type="checkbox" role="switch" id="toggle-led" name="toggle-led">

--- a/examples/simpleServer/simpleServer.ino
+++ b/examples/simpleServer/simpleServer.ino
@@ -83,7 +83,7 @@ void setup() {
     server.addOptionBox("Custom options");
     server.addOption("Test int variable", testInt);
     server.addOption("Test float variable", testFloat);
-    server.setSetupPageTitle("Async ESP FS<br>WebServer");
+    server.setSetupPageTitle("Simple Async ESP FS WebServer");
 
     // Enable ACE FS file web editor and add FS info callback fucntion
     server.enableFsCodeEditor();
@@ -95,7 +95,7 @@ void setup() {
 
     // Start server
     server.init();
-    Serial.print(F("ESP Web Server started on IP Address: "));
+    Serial.print(F("Async ESP Web Server started on IP Address: "));
     Serial.println(myIP);
     Serial.println(F(
         "This is \"simpleServer.ino\" example.\n"

--- a/examples/simpleServerCaptive/data/index.htm
+++ b/examples/simpleServerCaptive/data/index.htm
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-  <title>ESP simpleServer.ino</title>
+  <title>ESP simpleServerCaptive.ino</title>
   
   <!--Pico - Minimal CSS Framework for semantic info: HTML https://picocss.com/ -->
   <link rel="stylesheet" type="text/css" href="css/pico.fluid.classless.css">
@@ -31,7 +31,7 @@
       <article class="grid">
         <div>
           <hgroup>
-            <h1>ESP FS WebServer - LED Switcher</h1>
+            <h1>ESP Async FS WebServer - LED Switcher - simpleServerCaptive.ino</h1>
           </hgroup>
           <label for="remember">
             <input type="checkbox" role="switch" id="toggle-led" name="toggle-led">

--- a/examples/simpleServerCaptive/simpleServerCaptive.ino
+++ b/examples/simpleServerCaptive/simpleServerCaptive.ino
@@ -64,13 +64,18 @@ void setup() {
     IPAddress myIP = server.startWiFi(15000);
     if (!myIP) {
         Serial.println("\n\nNo WiFi connection, start AP and Captive Portal\n");
+        myIP = WiFi.softAPIP();
+        Serial.print("My IP 1 ");
+        Serial.println(myIP.toString());
         server.startCaptivePortal("ESP_AP", "123456789", "/setup");
         myIP = WiFi.softAPIP();
+        Serial.print("\nMy IP 2 ");
+        Serial.println(myIP.toString());
         captiveRun = true;
     }
 
     // Set a custom /setup page title
-    server.setSetupPageTitle("Simple Async FS<br>Web Server");
+    server.setSetupPageTitle("Simple Async FS Captive Web Server");
 
     // Enable ACE FS file web editor and add FS info callback fucntion
     server.enableFsCodeEditor();
@@ -83,10 +88,10 @@ void setup() {
 
     // Start server
     server.init();
-    Serial.print(F("ESP Web Server started on IP Address: "));
+    Serial.print(F("Async ESP Web Server started on IP Address: "));
     Serial.println(myIP);
     Serial.println(F(
-        "This is \"simpleServer.ino\" example.\n"
+        "This is \"simpleServerCaptive.ino\" example.\n"
         "Open /setup page to configure optional parameters.\n"
         "Open /edit page to view, edit or upload example or your custom webserver source files."
     ));

--- a/src/AsyncFsWebServer.h
+++ b/src/AsyncFsWebServer.h
@@ -30,7 +30,7 @@
 #define CONFIG_FILE "/config.json"
 
 #define DBG_OUTPUT_PORT     Serial
-#define LOG_LEVEL           2         // (0 disable, 1 error, 2 info, 3 debug)
+#define LOG_LEVEL           3         // (0 disable, 1 error, 2 info, 3 debug)
 #include "SerialLog.h"
 #include "CaptiverPortal.hpp"
 
@@ -175,7 +175,7 @@ class AsyncFsWebServer : public AsyncWebServer
     * Set current firmware version (shown in /setup webpage)
     */
     void setFirmwareVersion(char* version) {
-      strncpy(m_version, version, sizeof(m_version));
+      strlcpy(m_version, version, sizeof(m_version));
     }
 
     /*


### PR DESCRIPTION
Some issues mentioned in #11 and #10 were solved here.
send favicon.ico when available in FS.
fix MDNS.begin arg;incompatible; compile error on PIO but not on Arduino IDE(?). 
Fix unused static int i; compile error on Arduino IDE but not on PIO. 
Transfer IP addresses in json as string (2x), not LE integer (not portable). 
TODO: update setup.htm "esp-ip" to receive IP address as string iso. int (simpler). 
Update two related examples simpleServer & simpleServerCaptive.