### PR TITLE
Platform IO support

### DIFF
--- a/pio_ci_ex_ALL.bat
+++ b/pio_ci_ex_ALL.bat
@@ -1,5 +1,6 @@
 @echo off
 rem Build all listed examples of this library on PIO CLI; may take some time
+rem Verifies that library and all examples still compile
 
 setlocal EnableDelayedExpansion enableextensions
 set CI_DIR=%~dp0\..\async-esp-fs-webserver.pio-ci
@@ -10,6 +11,7 @@ FOR  %%E IN (%EXAMPLES%) DO IF NOT EXIST %CI_DIR%\ci_ex_%%E MKDIR %CI_DIR%\ci_ex
 @echo on
 FOR  %%E IN (%EXAMPLES%) DO (
  pio ci  -c platformio.ini --board=esp32dev --keep-build-dir --build-dir=%CI_DIR%\ci_ex_%%E --lib=. .\examples\%%E\*.* > %CI_DIR%\ci_ex_%%E\build.out.txt 2>%CI_DIR%\ci_ex_%%E\build.err.txt
+ @for /f %%i in ("%CI_DIR%\ci_ex_%%E\build.err.txt") do @set size=%%~zi && @echo ###ERROR in %%i && @type %%i
  )
 @echo off
 :: type %CI_DIR%/ci_ex_%%E/build.err.txt

--- a/pio_ci_ex_ALL.bat
+++ b/pio_ci_ex_ALL.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Build all listed examples of this library on PIO CLI; may take some time
+
+setlocal EnableDelayedExpansion enableextensions
+set CI_DIR=%~dp0\..\async-esp-fs-webserver.pio-ci
+set EXAMPLES=simpleServerCaptive simpleServer withWebSocket customHTML customOptions gpio_list handleFormData highcharts remoteOTA esp32-cam
+::set EXAMPLES=simpleServerCaptive
+:: simpleServer withWebSocket customHTML
+FOR  %%E IN (%EXAMPLES%) DO IF NOT EXIST %CI_DIR%\ci_ex_%%E MKDIR %CI_DIR%\ci_ex_%%E
+@echo on
+FOR  %%E IN (%EXAMPLES%) DO (
+ pio ci  -c platformio.ini --board=esp32dev --keep-build-dir --build-dir=%CI_DIR%\ci_ex_%%E --lib=. .\examples\%%E\*.* > %CI_DIR%\ci_ex_%%E\build.out.txt 2>%CI_DIR%\ci_ex_%%E\build.err.txt
+ )
+@echo off
+:: type %CI_DIR%/ci_ex_%%E/build.err.txt
+:: note activation pio verbose option '-v' outputs a lot of text (~25k/compile, ~2MB/pio-ci)
+rem pio ci  -c platformio.ini --board=esp32dev --build-dir=../ci_ex_simpleServer --keep-build-dir --lib=. .\examples\simpleServer\simpleServer.ino

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps = bblanchon/ArduinoJson@^6.21.4
+  DNSServer@^2.0.0
+  ESPmDNS@^2.0.0
+  WiFi@^2.0.0
+  FS@^2.0.0
+  LittleFS@^2.0.0
+  Update@^2.0.0
+
+

--- a/src/AsyncFsWebServer.cpp
+++ b/src/AsyncFsWebServer.cpp
@@ -69,7 +69,7 @@ bool AsyncFsWebServer::init(AwsEventHandler wsHandle) {
     begin();
 
     // Configure and start MDNS responder
-    if (!MDNS.begin(m_host)){
+    if (!MDNS.begin(m_host.c_str())){
         log_error("MDNS responder started");
     }
     MDNS.addService("http", "tcp", m_port);
@@ -122,7 +122,7 @@ void AsyncFsWebServer::enableFsCodeEditor() {
   }
 
 bool AsyncFsWebServer::startCaptivePortal(const char* ssid, const char* pass, const char* redirectTargetURL) {
-    
+
     if (! WiFi.softAP(ssid, pass)) {
         log_error("Captive portal failed to start: WiFi.softAP failed!");
         return false;
@@ -454,7 +454,6 @@ void AsyncFsWebServer::handleUpload(AsyncWebServerRequest *request, String filen
 
     if (len) {
         // stream the incoming chunk to the opened file
-        static int i = 0;
         request->_tempFile.write(data, len);
     }
 
@@ -545,12 +544,12 @@ void AsyncFsWebServer::doWifiConnection(AsyncWebServerRequest *request) {
         WiFi.mode(WIFI_AP_STA);
 
         // Manual connection setup
-        if (config) {            
+        if (config) {
             log_info("Manual config WiFi connection with IP: %s", local_ip.toString().c_str());
-            if (!WiFi.config(local_ip, gateway, subnet))           
+            if (!WiFi.config(local_ip, gateway, subnet))
                 log_error("STA Failed to configure");
         }
-        
+
         Serial.printf("\n\n\nConnecting to %s\n", ssid.c_str());
         WiFi.begin(ssid.c_str(), pass.c_str());
         delay(500);
@@ -693,7 +692,7 @@ IPAddress AsyncFsWebServer::startWiFi(uint32_t timeout, CallbackF fn ) {
             subnet.fromString(doc["subnet"].as<String>());
             local_ip.fromString(doc["ip_address"].as<String>());
             log_info("Manual config WiFi connection with IP: %s\n", local_ip.toString().c_str());
-            if (!WiFi.config(local_ip, gateway, subnet))           
+            if (!WiFi.config(local_ip, gateway, subnet))
                 log_error("STA Failed to configure");
             delay(100);
         }
@@ -745,8 +744,8 @@ IPAddress AsyncFsWebServer::startWiFi(uint32_t timeout, CallbackF fn ) {
 }
 
 IPAddress AsyncFsWebServer::startWiFi(uint32_t timeout, const char *apSSID, const char *apPsw, CallbackF fn) {
-    IPAddress ip (0, 0, 0, 0);  
-    ip = startWiFi(timeout, fn);    
+    IPAddress ip (0, 0, 0, 0);
+    ip = startWiFi(timeout, fn);
     if (!ip) {
         // No connection, start AP and then captive portal
         startCaptivePortal("ESP_AP", "123456789", "/setup");


### PR DESCRIPTION
Allow to use this library on PlatformIO by adding platformio.ini, and use CI batch file (sorry Linux guys) to compile library and all code examples. The generated firmware.bin files can be used for OTA update, and the build-in /setup can be used to update FS data of each example.