### PR TITLE
Platform io update: add CI build of library and examples for both ESP8266 and ESP32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# PlatformIO in VScode
+.pio/
+.vscode/
+*.lnk
+*.bak

--- a/examples/simpleServer/data/index.htm
+++ b/examples/simpleServer/data/index.htm
@@ -31,7 +31,7 @@
       <article class="grid">
         <div>
           <hgroup>
-            <h1>ESP FS WebServer - LED Switcher</h1>
+            <h1>ESP Async FS WebServer - LED Switcher - simpleServer.ino</h1>
           </hgroup>
           <label for="remember">
             <input type="checkbox" role="switch" id="toggle-led" name="toggle-led">

--- a/examples/simpleServer/simpleServer.ino
+++ b/examples/simpleServer/simpleServer.ino
@@ -83,7 +83,7 @@ void setup() {
     server.addOptionBox("Custom options");
     server.addOption("Test int variable", testInt);
     server.addOption("Test float variable", testFloat);
-    server.setSetupPageTitle("Async ESP FS<br>WebServer");
+    server.setSetupPageTitle("Simple Async ESP FS WebServer");
 
     // Enable ACE FS file web editor and add FS info callback fucntion
     server.enableFsCodeEditor();
@@ -95,7 +95,7 @@ void setup() {
 
     // Start server
     server.init();
-    Serial.print(F("ESP Web Server started on IP Address: "));
+    Serial.print(F("Async ESP Web Server started on IP Address: "));
     Serial.println(myIP);
     Serial.println(F(
         "This is \"simpleServer.ino\" example.\n"

--- a/examples/simpleServerCaptive/data/index.htm
+++ b/examples/simpleServerCaptive/data/index.htm
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-  <title>ESP simpleServer.ino</title>
+  <title>ESP simpleServerCaptive.ino</title>
   
   <!--Pico - Minimal CSS Framework for semantic info: HTML https://picocss.com/ -->
   <link rel="stylesheet" type="text/css" href="css/pico.fluid.classless.css">
@@ -31,7 +31,7 @@
       <article class="grid">
         <div>
           <hgroup>
-            <h1>ESP FS WebServer - LED Switcher</h1>
+            <h1>ESP Async FS WebServer - LED Switcher - simpleServerCaptive.ino</h1>
           </hgroup>
           <label for="remember">
             <input type="checkbox" role="switch" id="toggle-led" name="toggle-led">

--- a/examples/simpleServerCaptive/simpleServerCaptive.ino
+++ b/examples/simpleServerCaptive/simpleServerCaptive.ino
@@ -64,13 +64,18 @@ void setup() {
     IPAddress myIP = server.startWiFi(15000);
     if (!myIP) {
         Serial.println("\n\nNo WiFi connection, start AP and Captive Portal\n");
+        myIP = WiFi.softAPIP();
+        Serial.print("My IP 1 ");
+        Serial.println(myIP.toString());
         server.startCaptivePortal("ESP_AP", "123456789", "/setup");
         myIP = WiFi.softAPIP();
+        Serial.print("\nMy IP 2 ");
+        Serial.println(myIP.toString());
         captiveRun = true;
     }
 
     // Set a custom /setup page title
-    server.setSetupPageTitle("Simple Async FS<br>Web Server");
+    server.setSetupPageTitle("Simple Async FS Captive Web Server");
 
     // Enable ACE FS file web editor and add FS info callback fucntion
     server.enableFsCodeEditor();
@@ -83,10 +88,10 @@ void setup() {
 
     // Start server
     server.init();
-    Serial.print(F("ESP Web Server started on IP Address: "));
+    Serial.print(F("Async ESP Web Server started on IP Address: "));
     Serial.println(myIP);
     Serial.println(F(
-        "This is \"simpleServer.ino\" example.\n"
+        "This is \"simpleServerCaptive.ino\" example.\n"
         "Open /setup page to configure optional parameters.\n"
         "Open /edit page to view, edit or upload example or your custom webserver source files."
     ));

--- a/pio_ci_ex_ALL.bat
+++ b/pio_ci_ex_ALL.bat
@@ -3,17 +3,36 @@ rem Build all listed examples of this library on PIO CLI; may take some time
 rem Verifies that library and all examples still compile
 
 setlocal EnableDelayedExpansion enableextensions
-set CI_DIR=%~dp0\..\async-esp-fs-webserver.pio-ci
+set CI_DIR=%~dp0..\async-esp-fs-webserver.pio-ci
 set EXAMPLES=simpleServerCaptive simpleServer withWebSocket customHTML customOptions gpio_list handleFormData highcharts remoteOTA esp32-cam
 ::set EXAMPLES=simpleServerCaptive
 :: simpleServer withWebSocket customHTML
-FOR  %%E IN (%EXAMPLES%) DO IF NOT EXIST %CI_DIR%\ci_ex_%%E MKDIR %CI_DIR%\ci_ex_%%E
-@echo on
-FOR  %%E IN (%EXAMPLES%) DO (
- pio ci  -c platformio.ini --board=esp32dev --keep-build-dir --build-dir=%CI_DIR%\ci_ex_%%E --lib=. .\examples\%%E\*.* > %CI_DIR%\ci_ex_%%E\build.out.txt 2>%CI_DIR%\ci_ex_%%E\build.err.txt
- @for /f %%i in ("%CI_DIR%\ci_ex_%%E\build.err.txt") do @set size=%%~zi && @echo ###ERROR in %%i && @type %%i
- )
-@echo off
-:: type %CI_DIR%/ci_ex_%%E/build.err.txt
-:: note activation pio verbose option '-v' outputs a lot of text (~25k/compile, ~2MB/pio-ci)
-rem pio ci  -c platformio.ini --board=esp32dev --build-dir=../ci_ex_simpleServer --keep-build-dir --lib=. .\examples\simpleServer\simpleServer.ino
+set BOARDS= esp32dev esp12e
+set OPT_esp12e=-O "lib_deps=ArduinoJson@6.21.4"
+set OPT_esp32dev=-O "lib_deps=ArduinoJson@6.21.4"
+set NOT_esp12e=esp32-cam
+set NOT_esp32dev=esp8266-app
+set EXCLIB= --exclude=lib\*\.git* --exclude=lib\*\.pio --exclude=lib\*\.vscode --exclude=lib\*\built-in-webpages --exclude=lib\*\examples
+
+FOR  %%B IN (%BOARDS%) DO (
+  FOR %%E IN (%EXAMPLES%) DO (
+    if %%E==!NOT_%%B! (
+      echo ### not compiling %%E for %%B
+    ) else (
+      set CIEXDIR=%CI_DIR%\ci_ex_%%B_%%E
+      IF EXIST "!CIEXDIR!" RMDIR /s/q "!CIEXDIR!"
+      MKDIR "!CIEXDIR!"
+      set OPT=!OPT_%%B!
+      set OUT="!CIEXDIR!\build.out.txt"
+      set ERR="!CIEXDIR!\build.err.txt"
+      echo ### Compiling %%E for %%B
+      echo +pio ci  -b %%B !OPT! --keep-build-dir --build-dir="!CIEXDIR!\" --lib=. %EXCLIB%  .\examples\%%E\*.*   1^>!OUT!  2^>!ERR!
+      pio ci -b %%B !OPT! --keep-build-dir --build-dir="!CIEXDIR!" --lib=. %EXCLIB%  .\examples\%%E\*.*   >!OUT!  2>!ERR!
+      FOR /f %%i IN (!ERR!) DO IF EXIST %%i IF %%~zi GTR 0 ECHO ###ERROR in %%i && TYPE %%i
+    )
+    echo ### DONE
+  )
+)
+
+:: note activation pio verbose option '-v' generates a lot of output (~25k/compile, ~2MB/pio-ci)
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,9 +9,9 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
+framework = arduino
 platform = espressif32
 board = esp32dev
-framework = arduino
 lib_deps = bblanchon/ArduinoJson@^6.21.4
   DNSServer@^2.0.0
   ESPmDNS@^2.0.0
@@ -21,3 +21,13 @@ lib_deps = bblanchon/ArduinoJson@^6.21.4
   Update@^2.0.0
 
 
+[env:esp12e]
+framework = arduino
+platform = espressif8266
+board = esp12e
+board_build.mcu = esp8266
+lib_deps = bblanchon/ArduinoJson@^6.21.4
+  DNSServer@^1.1.0
+  ESP8266mDNS@^1.2
+  ESP8266WiFi@^1.0
+  LittleFS

--- a/src/AsyncFsWebServer.cpp
+++ b/src/AsyncFsWebServer.cpp
@@ -21,7 +21,7 @@ bool AsyncFsWebServer::init(AwsEventHandler wsHandle) {
     //////////////////////    BUILT-IN HANDLERS    ////////////////////////////
     using namespace std::placeholders;
 
-    on("/favicon.ico", HTTP_GET, std::bind(&AsyncFsWebServer::sendOK, this, _1));
+    //on("/favicon.ico", HTTP_GET, std::bind(&AsyncFsWebServer::sendOK, this, _1));
     on("/connect", HTTP_POST, std::bind(&AsyncFsWebServer::doWifiConnection, this, _1));
     on("/scan", HTTP_GET, std::bind(&AsyncFsWebServer::handleScanNetworks, this, _1));
     on("/wifistatus", HTTP_GET, std::bind(&AsyncFsWebServer::getStatus, this, _1));
@@ -240,14 +240,14 @@ void AsyncFsWebServer::notFound(AsyncWebServerRequest *request) {
 }
 
 void AsyncFsWebServer::getStatus(AsyncWebServerRequest *request) {
-    uint32_t ip = (WiFi.status() == WL_CONNECTED) ? WiFi.localIP() : WiFi.softAPIP();
+    IPAddress ip = (WiFi.status() == WL_CONNECTED) ? WiFi.localIP() : WiFi.softAPIP();
     String reply = "{\"firmware\": \"";
     reply += m_version;
     reply += "\", \"mode\":\"";
-    reply += WiFi.status() == WL_CONNECTED ? "Station" : "Access Point";
-    reply += "\", \"ip\":";
-    reply += ip;
-    reply += "}";
+    reply += WiFi.status() == WL_CONNECTED ? "Station " + WiFi.SSID() : "Access Point";
+    reply += "\", \"ip\":\"";
+    reply += ip.toString();
+    reply += "\"}";
     request->send(200, "application/json", reply);
 }
 
@@ -951,7 +951,7 @@ void AsyncFsWebServer::handleFsStatus(AsyncWebServerRequest *request)
     json += info.fsName;
     json += "\", \"isOk\":";
     if (m_filesystem_ok)  {
-        uint32_t ip = (WiFi.status() == WL_CONNECTED) ? WiFi.localIP() : WiFi.softAPIP();
+        IPAddress ip = (WiFi.status() == WL_CONNECTED) ? WiFi.localIP() : WiFi.softAPIP();
         json += PSTR("\"true\", \"totalBytes\":\"");
         json += info.totalBytes;
         json += PSTR("\", \"usedBytes\":\"");
@@ -961,7 +961,7 @@ void AsyncFsWebServer::handleFsStatus(AsyncWebServerRequest *request)
         json += PSTR("\", \"ssid\":\"");
         json += WiFi.SSID();
         json += PSTR("\", \"ip\":\"");
-        json += ip;
+        json += ip.toString();
         json += "\"";
     }
     else

--- a/src/AsyncFsWebServer.h
+++ b/src/AsyncFsWebServer.h
@@ -30,7 +30,7 @@
 #define CONFIG_FILE "/config.json"
 
 #define DBG_OUTPUT_PORT     Serial
-#define LOG_LEVEL           2         // (0 disable, 1 error, 2 info, 3 debug)
+#define LOG_LEVEL           3         // (0 disable, 1 error, 2 info, 3 debug)
 #include "SerialLog.h"
 #include "CaptiverPortal.hpp"
 
@@ -175,7 +175,7 @@ class AsyncFsWebServer : public AsyncWebServer
     * Set current firmware version (shown in /setup webpage)
     */
     void setFirmwareVersion(char* version) {
-      strncpy(m_version, version, sizeof(m_version));
+      strlcpy(m_version, version, sizeof(m_version));
     }
 
     /*


### PR DESCRIPTION
I added CI build of library and examples for both ESP8266 and ESP32
with possible exceptions of examples that aren't compatible for either CPU's.
I have chosen a generic board type for each processor type, and that is controlled all in the batch file, unrelated to settings in platformio.ini.